### PR TITLE
Travelers-Hub: (Fetch & Display Missions-Missions-API)

### DIFF
--- a/src/Components/Missions/Missions.js
+++ b/src/Components/Missions/Missions.js
@@ -15,7 +15,6 @@ const Missions = () => {
   // Get missions from the API
   useEffect(() => {
     dispatch(fetchMissions());
-    console.log(missions);
   }, [dispatch]);
 
   return (
@@ -32,22 +31,22 @@ const Missions = () => {
         <tbody>
           { missions && missions.map((mission) => (
             <tr key={mission.id}>
-            <th scope="row"><h5>{mission.name}</h5></th>
-            <td>
-              <p>
-                {mission.description}
-              </p>
-            </td>
-            <td>
-              { mission.joined ? <Badge className="m-2" bg="active" style={{backgroundColor: '#18a2b8'}}>Active Member</Badge>
-                               : <Badge className="m-2 " bg="secondary">NOT A MEMBER</Badge>}
-              {' '}
-            </td>
-            <td>
-              <Button className="m-4" variant="outline-danger text-nowrap">Leave Mission</Button>
-              {' '}
-            </td>
-          </tr>
+              <th scope="row"><h5>{mission.name}</h5></th>
+              <td>
+                <p>
+                  {mission.description}
+                </p>
+              </td>
+              <td>
+                { mission.joined ? <Badge className="m-2" bg="active" style={{ backgroundColor: '#18a2b8' }}>Active Member</Badge>
+                  : <Badge className="m-2 " bg="secondary">NOT A MEMBER</Badge>}
+                {' '}
+              </td>
+              <td>
+                <Button className="m-4" variant="outline-danger text-nowrap">Leave Mission</Button>
+                {' '}
+              </td>
+            </tr>
           ))}
         </tbody>
       </Table>

--- a/src/Components/Missions/Missions.js
+++ b/src/Components/Missions/Missions.js
@@ -1,44 +1,58 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Table from 'react-bootstrap/Table';
 import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
+import { fetchMissions } from '../../redux/configureStore';
 // import styling
 import styles from './Missions.module.css';
 
-const Missions = () => (
-  <div className={styles['missions-container']}>
-    <Table striped bordered hover responsive="xl" size="sm">
-      <thead>
-        <tr>
-          <th className="w-20 p-2" scope="col"><h4>Mission</h4></th>
-          <th className="w-20 p-2" scope="col"><h4>Description</h4></th>
-          <th className="w-15 p-2" scope="col"><h4>Status</h4></th>
-          <th className="w-15 p-2" scope="col"> </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th className="align-items-center" scope="row"><h5>Thaicom</h5></th>
-          <td>
-            <p>
-              Thaicom is a series of communications satellites operated by
-              Thaicom Public Company Limited. The first satellite in the series, Thaicom 1,
-              was launched in 1997. The most recent satellite in the series,
-              Thaicom 8, was launched in 2019.
-            </p>
-          </td>
-          <td>
-            <Badge className="align-self-center m-4" bg="secondary">NOT A MEMBER</Badge>
-            {' '}
-          </td>
-          <td>
-            <Button className="m-4" variant="outline-danger text-nowrap">Leave mission</Button>
-            {' '}
-          </td>
-        </tr>
-      </tbody>
-    </Table>
-  </div>
-);
+const Missions = () => {
+  // Get missions from the store
+  const missions = useSelector((state) => state.missions);
+  // Get dispatch function
+  const dispatch = useDispatch();
+  // Get missions from the API
+  useEffect(() => {
+    dispatch(fetchMissions());
+    console.log(missions);
+  }, [dispatch]);
+
+  return (
+    <div className={styles['missions-container']}>
+      <Table striped bordered hover responsive="xl" size="sm">
+        <thead>
+          <tr>
+            <th className="p-2" scope="col"><h4>Mission</h4></th>
+            <th className="p-2" scope="col"><h4>Description</h4></th>
+            <th className="p-2" scope="col"><h4>Status</h4></th>
+            <th className="p-2" scope="col"> </th>
+          </tr>
+        </thead>
+        <tbody>
+          { missions && missions.map((mission) => (
+            <tr key={mission.id}>
+            <th scope="row"><h5>{mission.name}</h5></th>
+            <td>
+              <p>
+                {mission.description}
+              </p>
+            </td>
+            <td>
+              { mission.joined ? <Badge className="m-2" bg="active" style={{backgroundColor: '#18a2b8'}}>Active Member</Badge>
+                               : <Badge className="m-2 " bg="secondary">NOT A MEMBER</Badge>}
+              {' '}
+            </td>
+            <td>
+              <Button className="m-4" variant="outline-danger text-nowrap">Leave Mission</Button>
+              {' '}
+            </td>
+          </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+};
 
 export default Missions;

--- a/src/Components/Missions/Missions.module.css
+++ b/src/Components/Missions/Missions.module.css
@@ -7,3 +7,7 @@
   height: 100%;
   padding: 0 30px;
 }
+
+.missions-container td {
+  vertical-align: middle;
+}

--- a/src/Components/Rocket/Rocket.js
+++ b/src/Components/Rocket/Rocket.js
@@ -1,29 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket } from '../../redux/rockets/rockets';
 // import styles
 import styles from './Rocket.module.css';
 // import rocketImg from './rocket.jpg';
 
 const Rocket = ({
+  id,
   name,
   description,
   image,
   reserved,
-}) => (
-  <div className={styles['rocket-container']}>
-    <img className={styles['rocket-img']} src={image} alt="rocket" />
-    <div className={styles['rocket-info']}>
-      <div className={styles['rocket-name']}>
-        <h2>{name}</h2>
-        {reserved && <span className={styles.badge}>Reserved</span>}
+}) => {
+
+  const dispatch = useDispatch();
+  const handleClick = () => {
+    dispatch(reserveRocket(id));
+  };
+
+  return (
+    <div className={styles['rocket-container']}>
+      <img className={styles['rocket-img']} src={image} alt="rocket" />
+      <div className={styles['rocket-info']}>
+        <div className={styles['rocket-name']}>
+          <h2>{name}</h2>
+          {reserved && <span className={styles.badge}>Reserved</span>}
+        </div>
+        <p>{description}</p>
+        <button type="button" className={styles['reserve-btn']} onClick={handleClick}>Reserve Rocket</button>
       </div>
-      <p>{description}</p>
-      <button type="button" className={styles['reserve-btn']}>Reserve Rocket</button>
     </div>
-  </div>
-);
+  );
+}
 
 Rocket.propTypes = {
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,

--- a/src/Components/Rocket/Rocket.js
+++ b/src/Components/Rocket/Rocket.js
@@ -13,7 +13,6 @@ const Rocket = ({
   image,
   reserved,
 }) => {
-
   const dispatch = useDispatch();
   const handleClick = () => {
     dispatch(reserveRocket(id));
@@ -32,7 +31,7 @@ const Rocket = ({
       </div>
     </div>
   );
-}
+};
 
 Rocket.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,14 +1,16 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import rocketsReducer, { fetchRockets } from './rockets/rockets';
+import missionsReducer, { fetchMissions } from './missions/missions';
 
 const rootReducer = combineReducers({
   rockets: rocketsReducer,
+  missions: missionsReducer,
 });
 
 const store = configureStore({
   reducer: rootReducer,
 });
 
-export { fetchRockets };
+export { fetchRockets, fetchMissions };
 
 export default store;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,0 +1,58 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+// Missions API
+const missionsURL = 'https://api.spacexdata.com/v3/missions';
+
+// Actions
+const GET_MISSIONS = 'travelers-hub/missions/getMissions';
+const JOIN_MISSION = 'travelers-hub/missions/joinMission';
+
+// Initial State
+const initialState = [];
+
+// Creating the thunk for all actions
+export const fetchMissions = createAsyncThunk(
+  GET_MISSIONS,
+  async () => {
+    try {
+      const response = await axios.get(missionsURL);
+      return response.data;
+    } catch (error) {
+      return error;
+    }
+  },
+);
+
+export const joinMission = createAsyncThunk(
+  JOIN_MISSION,
+  async (id) => {
+    try {
+      const response = await axios.patch(`${missionsURL}/${id}`, { reserved: true });
+      return response.data;
+    } catch (error) {
+      return error;
+    }
+  },
+);
+
+// Creating the slice
+export const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMissions.fulfilled, (state, action) => {
+        const missions = action.payload.map((mission) => ({
+          id: mission.mission_id,
+          name: mission.mission_name,
+          description: mission.description,
+          joined: false,
+        }));
+        return missions;
+      });
+  },
+});
+
+// Exporting the reducer
+export default missionsSlice.reducer;

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -28,7 +28,7 @@ export const reserveRocket = createAsyncThunk(
   RESERVE_ROCKET,
   async (id) => {
     try {
-      console.log('Reserved button is clicked', id);
+      // console.log('Reserved button is clicked', id);
       const response = await axios.patch(`${rocketsURL}/${id}`, { reserved: true });
       return response.data;
     } catch (error) {

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -28,6 +28,7 @@ export const reserveRocket = createAsyncThunk(
   RESERVE_ROCKET,
   async (id) => {
     try {
+      console.log('Reserved button is clicked', id);
       const response = await axios.patch(`${rocketsURL}/${id}`, { reserved: true });
       return response.data;
     } catch (error) {


### PR DESCRIPTION
# Travelers-Hub: (Fetch & Display Missions-[Missions-API](https://api.spacexdata.com/v3/missions))

## In this pull request I did the followings:

- [x] Fetched data from the [Missions Endpoint](https://api.spacexdata.com/v3/missions) when user clicks the **Missions** tab in the navbar.
- [x] Once the data is fetched, dispatched an action to store the following selected data in Redux store:
  - mission_id.
  - mission_name.
  - description.
  - flickr_images.
- [x] Made sure to dispatch those actions **only once** and do not add data to store on every re-render (i.e. when changing views / using navigation).
- [x] Updated `styling` for the `Missions` view component.
- [x] Made sure that there are [no linter errors](https://github.com/microverseinc/linters-config).
- [x] Made sure that the project is perfectly working as intended.
- [x] Documented the project professionally.

----
## [❗Important: ] 
#### 👤I am the **only** contributor to this project, and that's because my block appeal got approved too late and there were no available groups to join. Therefore, **student success** asked me to work solo.